### PR TITLE
adding memory parameter on mergeUMI task to solve outofmemory issue

### DIFF
--- a/umiQC.wdl
+++ b/umiQC.wdl
@@ -321,11 +321,12 @@ task bamSplitDeduplication {
 task mergeUMIs {
     input {
         Array[File] umiMetrics
+        Int memory = 16
     }
 
     parameter_meta {
         umiMetrics: "An array of TSV files with UMI metrics"
-
+        memory: "Memory allocated for this job"
     }
 
     command <<<
@@ -346,7 +347,9 @@ task mergeUMIs {
         done
         sed -e 's/\s\+/\t/g' starter.tsv > mergedUMIMetrics.tsv 
     >>>
-
+    runtime {
+        memory: "~{memory}G"
+    }
     output {
         File mergedUMIMetrics = "mergedUMIMetrics.tsv"
     }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -43,6 +43,7 @@
             "umiQC.extractUMIs.memory": null,
             "umiQC.extractUMIs.modules": "barcodex-rs/0.1.2 rust/1.45.1",
             "umiQC.extractUMIs.timeout": null,
+            "umiQC.mergeUMIs.memory": null,
             "umiQC.fastq1": {
                 "contents": {
                     "configuration": "/.mounts/labs/gsi/testdata/umiQC/inputs/r1.fastq",


### PR DESCRIPTION
SOme of the test runs failed on mergeUMI task, the linux sort command killed by linux due to "Cannot allocate memory". This command will allocate memory based on available memory. 